### PR TITLE
[cwFarmed] Add command 'all' to enable/disable all options in one time

### DIFF
--- a/cwfarmed/cwfarmed.lua
+++ b/cwfarmed/cwfarmed.lua
@@ -354,6 +354,8 @@ local function checkCommand(words)
 		local msgcmd = msgcmd .. '/farmed pet [on/off]{nl}'..'Show or hide pet messages (now: '..flagpet..').{nl}'..'-----------{nl}';
 		local msgcmd = msgcmd .. '/farmed petmin [value]{nl}'..'Only show pet messages when x% is obtained (now: '..alertpet..').{nl}'..'-----------{nl}';
 
+		local msgcmd = msgcmd .. '/farmed all [on/off]{nl}'..'Show or hide all messages.{nl}'..'-----------{nl}';
+
 		return log(msgtitle..msgcmd);
 	end
 

--- a/cwfarmed/cwfarmed.lua
+++ b/cwfarmed/cwfarmed.lua
@@ -287,6 +287,27 @@ local function checkCommand(words)
 		end
 	end
 
+	if (cmd == 'all') then
+		local dsflag = table.remove(words,1);
+		local msgflag = 'Show [items, silver, xp, xpjob, pet] set to ['..dsflag..'].';
+		local set = true;
+		if (dsflag == 'on') then
+			set = true;
+		elseif (dsflag == 'off') then
+			set = false;
+		else
+			return ui.MsgBox(msgtitle.."The value should be 'on' or 'off' (without quotes). Not '"..getvarvalue(dsflag).."' as informed.");
+		end
+		
+		options.show['items'] = set;
+		options.show['silver'] = set;
+		options.show['xp'] = set;
+		options.show['xpjob'] = set;
+		options.show['pet'] = set;
+		cwAPI.json.save(options,'cwfarmed');
+		return ui.MsgBox(msgtitle..msgflag);
+	end
+
 	if (cmd == 'silvermin' or cmd == 'xpmin' or cmd == 'xpjobmin' or cmd == 'petmin') then
 		local newvlr = table.remove(words,1);
 		local atr = string.gsub(cmd,'min','');


### PR DESCRIPTION
Thanks to your add-on.
But it's not friendly to enable/disable all options.
So I create a new command do to that.
`/farmed all [on|off]`

This code was done quickly via github and was not tested in game. 
In addition, I don't know LUA.
But I think it's ok.

Feel free to modify it before merge.
Thanks
